### PR TITLE
bug: 퍼스널 화면진입 불가 버그 해결

### DIFF
--- a/src/api/goalApi.js
+++ b/src/api/goalApi.js
@@ -1,5 +1,5 @@
 // 목표 관련 api 함수 모음
-import axios from 'axios';
+import axios from './index.js';
 
 const api = axios.create({
   baseURL: '/api',

--- a/src/pages/search/policySearch/PolicySearchPage.vue
+++ b/src/pages/search/policySearch/PolicySearchPage.vue
@@ -554,62 +554,104 @@ onMounted(async () => {
   // 콘솔: 퍼스널 정보 전체 확인
   console.log('[userProfile]', userProfile);
 
-  // 지역
-  const regionLabel = RegionEnum?.[userProfile.region]?.label;
-  if (regionLabel) {
-    try {
-      const zipCodes = await fetchZipCodesBySido(regionLabel);
-      filterState.value.region = zipCodes;
-      console.log('[퍼스널 지역 → zipCodes]', zipCodes);
-    } catch (e) {
-      console.error('퍼스널 지역 zipCode 불러오기 실패', e);
+  if (userProfile) {
+    const regionLabel = RegionEnum?.[userProfile.region]?.label;
+    if (regionLabel) {
+      try {
+        const zipCodes = await fetchZipCodesBySido(regionLabel);
+        filterState.value.region = zipCodes;
+        console.log('[퍼스널 지역 → zipCodes]', zipCodes);
+      } catch (e) {
+        console.error('퍼스널 지역 zipCode 불러오기 실패', e);
+      }
     }
+
+    // 나이
+    if (userProfile.age) {
+      customAge.value = userProfile.age;
+    }
+
+    // 혼인 여부
+    const mrgSttsCode = getCodeFromEnum(
+      MaritalStatusEnum,
+      userProfile.marital_status
+    );
+    if (mrgSttsCode) filterState.value.maritalStatus = [mrgSttsCode];
+
+    // 연소득
+    if (userProfile.annual_income) {
+      customIncome.value = String(userProfile.annual_income);
+    }
+
+    // 학력
+    const educationCode = getCodeFromEnum(
+      EducationLevelEnum,
+      userProfile.education_level
+    );
+    if (educationCode) filterState.value.education = [educationCode];
+
+    // 취업 상태
+    const employmentCode = getCodeFromEnum(
+      EmploymentStatusEnum,
+      userProfile.employment_status
+    );
+    if (employmentCode) filterState.value.employment = [employmentCode];
+
+    // 전공
+    const majorCode = getCodeFromEnum(MajorEnum, userProfile.major);
+    if (majorCode) filterState.value.major = [majorCode];
+
+    // 특화 분야
+    const specialtyCode = getCodeFromEnum(SpecialtyEnum, userProfile.specialty);
+    if (specialtyCode) filterState.value.special = [specialtyCode];
+  } else {
+    console.warn('[경고] userProfile 없음: 퍼스널 정보 자동 필터 생략');
   }
 
-  // 나이
-  if (userProfile?.age) {
-    customAge.value = userProfile.age;
-  }
+  // // 나이
+  // if (userProfile?.age) {
+  //   customAge.value = userProfile.age;
+  // }
 
-  // 혼인 여부
-  const mrgSttsCode = getCodeFromEnum(
-    MaritalStatusEnum,
-    userProfile.marital_status
-  );
-  console.log('[혼인 여부 코드]', mrgSttsCode);
-  if (mrgSttsCode) filterState.value.maritalStatus = [mrgSttsCode];
+  // // 혼인 여부
+  // const mrgSttsCode = getCodeFromEnum(
+  //   MaritalStatusEnum,
+  //   userProfile.marital_status
+  // );
+  // console.log('[혼인 여부 코드]', mrgSttsCode);
+  // if (mrgSttsCode) filterState.value.maritalStatus = [mrgSttsCode];
 
-  // 연소득 자동 적용
-  if (userProfile.annual_income) {
-    customIncome.value = String(userProfile.annual_income);
-    console.log('[연소득 자동 적용]', customIncome.value);
-  }
+  // // 연소득 자동 적용
+  // if (userProfile.annual_income) {
+  //   customIncome.value = String(userProfile.annual_income);
+  //   console.log('[연소득 자동 적용]', customIncome.value);
+  // }
 
-  // 학력
-  const educationCode = getCodeFromEnum(
-    EducationLevelEnum,
-    userProfile.education_level
-  );
-  console.log('[학력 코드]', educationCode);
-  if (educationCode) filterState.value.education = [educationCode];
+  // // 학력
+  // const educationCode = getCodeFromEnum(
+  //   EducationLevelEnum,
+  //   userProfile.education_level
+  // );
+  // console.log('[학력 코드]', educationCode);
+  // if (educationCode) filterState.value.education = [educationCode];
 
-  // 취업 상태
-  const employmentCode = getCodeFromEnum(
-    EmploymentStatusEnum,
-    userProfile.employment_status
-  );
-  console.log('[취업 상태 코드]', employmentCode);
-  if (employmentCode) filterState.value.employment = [employmentCode];
+  // // 취업 상태
+  // const employmentCode = getCodeFromEnum(
+  //   EmploymentStatusEnum,
+  //   userProfile.employment_status
+  // );
+  // console.log('[취업 상태 코드]', employmentCode);
+  // if (employmentCode) filterState.value.employment = [employmentCode];
 
-  // 전공
-  const majorCode = getCodeFromEnum(MajorEnum, userProfile.major);
-  console.log('[전공 코드]', majorCode);
-  if (majorCode) filterState.value.major = [majorCode];
+  // // 전공
+  // const majorCode = getCodeFromEnum(MajorEnum, userProfile.major);
+  // console.log('[전공 코드]', majorCode);
+  // if (majorCode) filterState.value.major = [majorCode];
 
-  // 특화 분야
-  const specialtyCode = getCodeFromEnum(SpecialtyEnum, userProfile.specialty);
-  console.log('[특화 분야 코드]', specialtyCode);
-  if (specialtyCode) filterState.value.special = [specialtyCode];
+  // // 특화 분야
+  // const specialtyCode = getCodeFromEnum(SpecialtyEnum, userProfile.specialty);
+  // console.log('[특화 분야 코드]', specialtyCode);
+  // if (specialtyCode) filterState.value.special = [specialtyCode];
 
   // 정책 스크랩 여부 포함해서 저장
   policyList.value = data.map((p) => ({

--- a/src/pages/search/policySearch/policyDetailPage.vue
+++ b/src/pages/search/policySearch/policyDetailPage.vue
@@ -22,7 +22,11 @@
 
       <!-- 키워드 -->
       <div class="keywords" v-if="policy.plcyKywdNm">
-        <span v-for="(kw, i) in policy.plcyKywdNm.split(',')" :key="i" class="keyword">
+        <span
+          v-for="(kw, i) in policy.plcyKywdNm.split(',')"
+          :key="i"
+          class="keyword"
+        >
           #{{ kw.trim() }}
         </span>
       </div>
@@ -45,7 +49,9 @@
           </div>
           <div class="info-row">
             <span class="label">신청기간</span>
-            <span>{{ formatPeriod(policy.bizPrdBgngYmd, policy.bizPrdEndYmd) }}</span>
+            <span>{{
+              formatPeriod(policy.bizPrdBgngYmd, policy.bizPrdEndYmd)
+            }}</span>
           </div>
         </div>
       </section>
@@ -56,7 +62,10 @@
         <div class="info-list">
           <div class="info-row">
             <span class="label">연령</span>
-            <span>{{ policy.sprtTrgtMinAge }}세 ~ {{ policy.sprtTrgtMaxAge }}세</span>
+            <span
+              >{{ policy.sprtTrgtMinAge }}세 ~
+              {{ policy.sprtTrgtMaxAge }}세</span
+            >
           </div>
           <div class="info-row">
             <span class="label">거주지역</span>
@@ -66,11 +75,18 @@
             <span class="label">소득조건</span>
             <span>{{ convertLabel(policy.earnCndSeCd, 'income') }}</span>
           </div>
-          <div class="info-row" v-if="policy.earnMinAmt || policy.earnMaxAmt || policy.earnEtcCn">
+          <div
+            class="info-row"
+            v-if="policy.earnMinAmt || policy.earnMaxAmt || policy.earnEtcCn"
+          >
             <span class="label">소득금액</span>
             <span>
-              <span v-if="policy.earnMinAmt">최소 {{ formatCurrency(policy.earnMinAmt) }}</span>
-              <span v-if="policy.earnMaxAmt"> ~ 최대 {{ formatCurrency(policy.earnMaxAmt) }}</span>
+              <span v-if="policy.earnMinAmt"
+                >최소 {{ formatCurrency(policy.earnMinAmt) }}</span
+              >
+              <span v-if="policy.earnMaxAmt">
+                ~ 최대 {{ formatCurrency(policy.earnMaxAmt) }}</span
+              >
               <span v-if="policy.earnEtcCn"> ({{ policy.earnEtcCn }})</span>
             </span>
           </div>
@@ -101,7 +117,11 @@
       <section class="section card">
         <h2>신청 정보</h2>
         <p class="link">
-          <a :href="policy.aplyUrlAddr" target="_blank" rel="noopener noreferrer">
+          <a
+            :href="policy.aplyUrlAddr"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             {{ policy.aplyUrlAddr }}
           </a>
         </p>


### PR DESCRIPTION
## 📋 PR 유형
<!-- 해당하는 것에 ✅ 표시해주세요 -->
- [x] 🐛 버그 수정
- [ ] ✨ 새 기능 구현
- [ ] 📚 문서 업데이트
- [ ] 🔧 코드 리팩토링
- [ ] 🎨 스타일 변경
- [ ] ⚡ 성능 개선

## 📝 변경 사항

### 무엇을 변경했나요?

DB에 퍼스널 정보가 저장되지 않은 상태에서도 정책 탐색 페이지가 정상적으로 렌더링되도록 수정했습니다.  
`userProfile`이 존재할 때만 관련 필터를 적용하도록 조건문을 추가했습니다

**주요 변경사항:**
- `userProfile.region` 접근 전 null 체크 추가
- 퍼스널 정보가 없을 경우 자동 필터링을 생략하도록 변경

<details>
<summary>상세 변경 내용</summary>



</details>

### 왜 이 변경이 필요한가요?
- [x] 


## 📸 스크린샷 (필요한 경우)
<!-- UI 변경사항이 있다면 Before/After 스크린샷을 첨부해주세요 -->

> **Note**  
## ✅ 체크리스트
- [x] 코드 작성 완료
- [x]
## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 연결해주세요 -->
Closes #3
<!-- Related to #이슈번호 -->

## 📌 리뷰 포인트

> **Warning**  
> 다음 사항들을 중점적으로 리뷰해주세요
- [x]

## 🚀 테스트 방법

```bash
