### PR TITLE
feat: google, naver OAuth 추가를 위한 화면 수정

### DIFF
--- a/src/pages/auth/LoginPage.vue
+++ b/src/pages/auth/LoginPage.vue
@@ -14,7 +14,11 @@ const passwd = ref('');
 const showPassword = ref(false);
 const error = ref(''); // 에러 메시지
 const loading = ref(false);
-const kakaoLoading = ref(false);
+const socialLoading = ref({
+  kakao: false,
+  naver: false,
+  google: false,
+});
 
 const canSubmit = computed(() => id.value.trim() && passwd.value.trim());
 
@@ -61,33 +65,58 @@ async function login() {
 // 카카오 로그인
 async function loginWithKakao() {
   try {
-    kakaoLoading.value = true;
+    socialLoading.value.kakao = true;
     error.value = '';
 
-    console.log('카카오 로그인 URL 요청 중...');
-
-    // 백엔드에서 카카오 로그인 URL 받기
     const response = await api.get('/oauth/kakao/login-url');
     const kakaoAuthUrl = response.result;
 
-    console.log('카카오 로그인 시작');
-
-    // 현재 창에서 카카오 로그인 페이지로 이동
-    // 카카오 인증 완료 후 자동으로 /oauth/callback 으로 돌아옴
     window.location.href = kakaoAuthUrl;
   } catch (err) {
     console.error('카카오 로그인 URL 요청 실패:', err);
     error.value = '카카오 로그인을 시작할 수 없습니다.';
-    kakaoLoading.value = false;
+    socialLoading.value.kakao = false;
   }
 }
 
-function loginWithNaver() {
-  alert('네이버 로그인 시도');
+// 네이버 로그인
+async function loginWithNaver() {
+  try {
+    socialLoading.value.naver = true;
+    error.value = '';
+
+    console.log('네이버 로그인 URL 요청 중...');
+
+    const response = await api.get('/oauth/naver/login-url');
+    const naverAuthUrl = response.result;
+
+    console.log('네이버 로그인 시작');
+    window.location.href = naverAuthUrl;
+  } catch (err) {
+    console.error('네이버 로그인 URL 요청 실패:', err);
+    error.value = '네이버 로그인을 시작할 수 없습니다.';
+    socialLoading.value.naver = false;
+  }
 }
 
-function loginWithGoogle() {
-  alert('구글 로그인 시도');
+// 구글 로그인
+async function loginWithGoogle() {
+  try {
+    socialLoading.value.google = true;
+    error.value = '';
+
+    console.log('구글 로그인 URL 요청 중...');
+
+    const response = await api.get('/oauth/google/login-url');
+    const googleAuthUrl = response.result;
+
+    console.log('구글 로그인 시작');
+    window.location.href = googleAuthUrl;
+  } catch (err) {
+    console.error('구글 로그인 URL 요청 실패:', err);
+    error.value = '구글 로그인을 시작할 수 없습니다.';
+    socialLoading.value.google = false;
+  }
 }
 </script>
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -43,8 +43,20 @@ const routes = [
     beforeEnter: requiresAuth,
   },
   {
-    path: '/oauth/callback',
-    name: 'oauthCallback',
+    path: '/oauth/kakao/callback',
+    name: 'kakaoCallback',
+    component: () => import('../pages/auth/OAuthCallbackPage.vue'),
+    meta: { isHeader: false, isFooter: false },
+  },
+  {
+    path: '/oauth/naver/callback',
+    name: 'naverCallback',
+    component: () => import('../pages/auth/OAuthCallbackPage.vue'),
+    meta: { isHeader: false, isFooter: false },
+  },
+  {
+    path: '/oauth/google/callback',
+    name: 'googleCallback',
     component: () => import('../pages/auth/OAuthCallbackPage.vue'),
     meta: { isHeader: false, isFooter: false },
   },


### PR DESCRIPTION
## 📋 PR 유형
<!-- 해당하는 것에 ✅ 표시해주세요 -->
- [ ] 🐛 버그 수정
- [x] ✨ 새 기능 구현
- [ ] 📚 문서 업데이트
- [ ] 🔧 코드 리팩토링
- [ ] 🎨 스타일 변경
- [ ] ⚡ 성능 개선

## 📝 변경 사항

### 무엇을 변경했나요?
**주요 변경사항:**
- 네이버, 구글 소셜 로그인 버튼 및 기능 구현
- OAuth 콜백 처리를 위한 범용 콜백 페이지 구현
- 소셜 로그인 상태 관리 및 사용자 피드백 UI
- BaseResponse 형태의 API 응답 처리 인터셉터 개선

**주요 변경사항:**


<details>
<summary>상세 변경 내용</summary>

**로그인 페이지 (LoginPage.vue):**
- 카카오, 네이버, 구글 소셜 로그인 버튼 추가
- 각 제공자별 로딩 상태 및 에러 처리
- 소셜 로그인 버튼 디자인 및 아이콘 구현
- 기존 일반 로그인과 소셜 로그인 UI 통합

**OAuth 콜백 페이지 (OAuthCallbackPage.vue):**
- 범용 OAuth 콜백 처리 컴포넌트 구현
- URL 기반 OAuth 제공자 자동 감지 로직
- 로딩, 성공, 실패 상태별 사용자 피드백 UI
- 자동 페이지 리다이렉션 및 타이머 표시

**API 인터셉터 개선 (api/index.js):**
- BaseResponse 구조 자동 파싱 및 처리
- OAuth API 호출 시 적절한 에러 핸들링
- 토큰 기반 인증 헤더 자동 추가
- 401 에러 시 자동 로그아웃 처리

**라우터 설정:**
- OAuth 콜백 라우트 추가 (/oauth/{provider}/callback)
- 범용 콜백 라우트로 통합 관리
- 헤더/푸터 제외 설정으로 깔끔한 콜백 화면

**상태 관리:**
- 소셜 로그인별 로딩 상태 분리 관리
- 토큰 및 사용자 정보 로컬스토리지 저장
- 로그인 성공 시 메인 페이지 자동 이동

</details>

### 왜 이 변경이 필요한가요?
- [x] 


## 📸 스크린샷 (필요한 경우)
<!-- UI 변경사항이 있다면 Before/After 스크린샷을 첨부해주세요 -->

> **Note**  
## ✅ 체크리스트
- [x] 코드 작성 완료
- [x]
## 🔗 관련 이슈
#90 

